### PR TITLE
Slightly changing the way the calendar is positionned 

### DIFF
--- a/js/glDatePicker.js
+++ b/js/glDatePicker.js
@@ -296,8 +296,8 @@
 					{
 						"position":settings.position,
 						"z-index":settings.zIndex,
-						"left":(target.offset().left),
-						"top":target.offset().top+target.outerHeight(true)
+						"left":(target.position().left),
+						"top":target.position().top+target.outerHeight(true)
 					})
 				);
 			}


### PR DESCRIPTION
I use the jquery `position` method instead of `offset`.
In my project I couldn't find a way to position in an acceptable way the calendar, because I have some containers set with `position: relative`. Using the `position` method ensures the calendar is positionned well.

I found two solutions: add the calendar just before the `body`, or use the jquery `position` method. Don't know which one is the best...
