### PR TITLE
Add allowDays option to restrict to certain days of the week.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ to use and configure the plugin at: http://code.gautamlad.com/glDatePicker/
 - forward and back navigation
 - current date highlight
 - restricting selection of dates outside of a range
+- restricting to only certain days of the week
 - restricting selection of dates beyond N-days from start date
 - restricting forward / backwards month navigation
 - individual styles per date picker (in case you have multiples on one page)

--- a/js/glDatePicker.js
+++ b/js/glDatePicker.js
@@ -56,6 +56,7 @@
 		selectedDate: -1,
 		showPrevNext: true,
 		allowOld: true,
+		allowDays: [true, true, true, true, true, true, true],
 		showAlways: false,
 		position: "absolute"
 	};
@@ -235,6 +236,12 @@
 						if(!settings.allowOld)
 						{
 							c = (dateTime < startTime) ? "noday":c;
+						}
+						
+						// Test to see if we are allowed to pick this day of the week
+						if(!settings.allowDays[x])
+						{
+							c = "noday";
 						}
 
 						// Test against end date


### PR DESCRIPTION
This adds a new option to restrict the date picker to only certain days of the week, e.g. Monday through Friday, through an array-based configuration. The default is every day of the week (an array with 7 trues).
