### PR TITLE
Allow array to be passed through to selected dates

### DIFF
--- a/js/glDatePicker.js
+++ b/js/glDatePicker.js
@@ -243,10 +243,26 @@
 							c = (dateTime > endTime) ? "noday":c;
 						}
 
+						var dateArr = settings.selectedDate;
+
 						// Test against selected date
-						if(settings.selectedDate != -1)
-						{
-							c = (dateTime == selectedTime) ? "selected":c;
+						if(settings.selectedDate != -1) {
+							
+							var testDate = '';
+
+							for (var z = 0; z < dateArr.length; z++) {
+
+								dateArr[z].setHours(0,0,0,0);
+								testDate = dateArr[z].getTime();
+
+								if (dateTime == testDate) {
+									c = "selected";
+								} else {
+									c = c;
+								}
+
+							}
+
 						}
 					}
 					else


### PR DESCRIPTION
I recently adapted glDatePicker for a project I was working on to show multiple selected dates for a booking calendar.

With the code attached you can pass an array through to selected date.

```
var dates = new Array();
dates[0] = new Date('October 05, 2012');
dates[1] = new Date('October 06, 2012');
dates[2] = new Date('October 07, 2012');

$('#calendar').glDatePicker("setSelectedDate", dates);
```
