### PR TITLE
Re-render with new selected date

### DIFF
--- a/js/glDatePicker.js
+++ b/js/glDatePicker.js
@@ -137,6 +137,7 @@
 		setSelectedDate: function(e)
 		{
 			$(this).data("settings").selectedDate = e;
+			$(this).data("theDate", e);
             methods.update.apply($(this));
 		},
 

--- a/js/glDatePicker.js
+++ b/js/glDatePicker.js
@@ -137,6 +137,7 @@
 		setSelectedDate: function(e)
 		{
 			$(this).data("settings").selectedDate = e;
+            methods.update.apply($(this));
 		},
 
 		// Render the calendar
@@ -362,8 +363,8 @@
 						settings.onChange(target, newDate);
 					}
 
-					// Save selected
-					settings.selectedDate = newDate;
+					// Save selected and redisplay
+        			methods.setSelectedDate.call(target, newDate);
 
 					// Hide calendar
 					methods.hide.apply(target);


### PR DESCRIPTION
By default, when I select a date, the picker isn't re-rendered with the "selected" class on the newly-selected date. This is fine if you are just populating a text input, but I am using the showAlways: true option to just permanently display the calendar and really want selecting a date to cause the calendar to re-render.

(Note: I have not yet updated the min file because I seem to have different settings from you and the diff I got was enormous. I'd appreciate, if you want to incorporate this pull request, if you would do so.)

Thanks!
