### PR TITLE
Fix: onHover cell parameter is always the last cell in calendar

### DIFF
--- a/glDatePicker.js
+++ b/glDatePicker.js
@@ -629,7 +629,7 @@
 										var hoverData = $(this).data('data');
 
 										// Call callback
-										options.onHover(el, cell, hoverData.date, hoverData.data);
+										options.onHover(el, $(this), hoverData.date, hoverData.data);
 									})
 									.click(function(e) {
 										e.stopPropagation();


### PR DESCRIPTION
Cell is the last cell in the calendar on the onHover event
